### PR TITLE
Use relative paths for submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/external/binson-c-light"]
 	path = src/external/binson-c-light
-	url = https://github.com/assaabloy-ppi/binson-c-light
+	url = ../binson-c-light


### PR DESCRIPTION
@franslundberg @sijohans . When mirroring salt-channel-c it would be better if the submodule to binson-light-c was a relative path. What do you think about this? 