### PR TITLE
 host_echo example fix.

### DIFF
--- a/examples/host_echo.c
+++ b/examples/host_echo.c
@@ -164,8 +164,7 @@ static void *connection_handler(void *context)
             break;
         }
 
-        salt_handshake(&client->channel, NULL);
-
+        ret = salt_handshake(&client->channel, NULL);
     }
 
     printf("Salt handshake succeeded.\r\n");
@@ -193,7 +192,9 @@ static void *connection_handler(void *context)
             ret = salt_write_next(&msg_out, msg_in.read.p_payload, msg_in.read.message_size);
         }
 
-        salt_write_execute(&client->channel, &msg_out, false);
+        do {
+        ret = salt_write_execute(&client->channel, &msg_out, false);
+        } while (ret == SALT_PENDING);
 
     } while (ret == SALT_SUCCESS);
 

--- a/examples/host_echo.c
+++ b/examples/host_echo.c
@@ -193,7 +193,7 @@ static void *connection_handler(void *context)
         }
 
         do {
-        ret = salt_write_execute(&client->channel, &msg_out, false);
+            ret = salt_write_execute(&client->channel, &msg_out, false);
         } while (ret == SALT_PENDING);
 
     } while (ret == SALT_SUCCESS);


### PR DESCRIPTION
Examples provided in 'examples' directory of master branch do not work out-of-the box as described in README file.

Handling return values of salt_handshake and salt_write_execute instead of ignoring the values made the example work as described in README.

Return values handling issues may still exist as the ret variable is overwritten in in do/while loops.