### PR TITLE
Link with -pthread by default

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@ project(salt-channel-c)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
   SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -lpthread")
-elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+else ()
   SET(CMAKE_EXE_LINKER_FLAGS  "${CMAKE_EXE_LINKER_FLAGS} -pthread")
 endif()
 


### PR DESCRIPTION
Sometimes cmake fail to set the compiler ID. If that happens we miss the pthread linker option. So, use -pthread by default. 

@sijohans Please check