### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR to allow building as a submodule in other projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 2.8)
 project(salt-channel-c)
 enable_language(C)
 
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 find_package(Sanitizers)
 
 find_path(LIBSODIUM_INCLUDE_DIR


### PR DESCRIPTION
When using this repo as a submodule in a dependant application, it fails to locate some of the included .cmake files.

This is a simple change to ensure it uses a path relative to the current CMakeLists.txt rather than to the top-level project.