### PR TITLE
Makes examples/benchmark optional and disables tests by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,13 @@ else(LIBSODIUM_LIBRARY)
 	add_library(tweetnacl_modified src/external/tweetnacl_modified/tweetnacl_modified.c examples/randombytes_linux.c src/external/tweetnacl_modified/tweetnacl_modified_wrapper.c)
 endif(LIBSODIUM_LIBRARY)
 
-set(CMAKE_C_FLAGS_DEBUG "-fprofile-arcs -ftest-coverage -std=c99 ${CMAKE_CXX_FLAGS_DEBUG}")
-add_definitions(-O0 -g -ggdb -Wall -Werror -Wpedantic -Wshadow -std=c99)
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -DSALT_DEBUG=1")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Werror -Wpedantic -Wshadow -std=c99")
+
+OPTION(COVERAGE "Enable Code Coverage Support" ON)
+if(COVERAGE)
+	set(CMAKE_C_FLAGS_DEBUG "-fprofile-arcs -ftest-coverage")
+endif(COVERAGE)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,8 +35,16 @@ set(CMAKE_C_FLAGS_DEBUG "-fprofile-arcs -ftest-coverage -std=c99 ${CMAKE_CXX_FLA
 add_definitions(-O0 -g -ggdb -Wall -Werror -Wpedantic -Wshadow -std=c99)
 
 add_subdirectory(src)
-add_subdirectory(examples)
-add_subdirectory(benchmark)
+
+OPTION(BUILD_EXAMPLES "Build examples" ON)
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif(BUILD_EXAMPLES)
+
+OPTION(BUILD_BENCHMARK "Build benchmark" ON)
+if(BUILD_BENCHMARK)
+    add_subdirectory(benchmark)
+endif(BUILD_BENCHMARK)
 
 option(BUILD_TESTS "Build tests" ON)
 


### PR DESCRIPTION
When using this project as a dependency in an application, having the tests, examples and benchmark built makes assumptions that aren't necessarily true about the target platform. Example: when building for embedded systems Posix type sockets aren't a feature and test/mocking frameworks aren't always available out-of-the-box.

It's convenient to disable these targets unless specifically developing on the library itself.